### PR TITLE
nodejs: Add wrapper that stops node-js from making stdout non-blocking

### DIFF
--- a/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
+++ b/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
@@ -60,11 +60,20 @@
 	  "../shared-modules/gtk2/gtk2.json",
       {   "name": "nodejs",
           "make-install-args": ["prefix=/app"],
+          "post-install": [
+              "mv /app/bin/node /app/bin/real-node",
+              "install --mode=755 node-stdout-nonblocking-wrapper /app/bin/node"
+          ],
           "sources": [
               {
                   "type": "archive",
                   "url": "https://nodejs.org/dist/v8.12.0/node-v8.12.0.tar.gz",
                   "sha256" : "b4797843136edd9195c28221a1680ae52c29d867fc5fc1c99f7d6e2f2126a67b"
+              },
+              {
+                  "type": "script",
+                  "dest-filename": "node-stdout-nonblocking-wrapper",
+                  "commands": [ 'exec real-node "$@" 2>&1 | cat -' ]
               }
           ]
       },


### PR DESCRIPTION
The build is failing with errors writing to stdout due to a combination
of issues:

 * ./mach spawns make and reads the output one byte at a time
 * There are lots of make output due to the rustc debug logs enabled
 * node-js is run as part of the builds, and it leaves stdout non-blocking:
   https://github.com/nodejs/node/issues/14752

So, eventually some other commmand can't handle stdout being non-blocking, but
the pipe becomes (temporarily) full as mach can't keep up, and the whole
shitshow comes to a stop.